### PR TITLE
gymnasium==1.1.0 breaks ogbench.make_env_and_datasets()

### DIFF
--- a/ogbench/locomaze/ant.py
+++ b/ogbench/locomaze/ant.py
@@ -16,7 +16,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
 
     xml_file = os.path.join(os.path.dirname(__file__), 'assets', 'ant.xml')
     metadata = {
-        'render_modes': ['human', 'rgb_array', 'depth_array'],
+        'render_modes': ['human', 'rgb_array', 'depth_array', 'rgbd_tuple'],
         'render_fps': 10,
     }
 

--- a/ogbench/locomaze/humanoid.py
+++ b/ogbench/locomaze/humanoid.py
@@ -17,7 +17,7 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
 
     xml_file = os.path.join(os.path.dirname(__file__), 'assets', 'humanoid.xml')
     metadata = {
-        'render_modes': ['human', 'rgb_array', 'depth_array'],
+        'render_modes': ['human', 'rgb_array', 'depth_array', 'rgbd_tuple'],
         'render_fps': 40,
     }
 

--- a/ogbench/locomaze/point.py
+++ b/ogbench/locomaze/point.py
@@ -16,7 +16,7 @@ class PointEnv(MujocoEnv, utils.EzPickle):
 
     xml_file = os.path.join(os.path.dirname(__file__), 'assets', 'point.xml')
     metadata = {
-        'render_modes': ['human', 'rgb_array', 'depth_array'],
+        'render_modes': ['human', 'rgb_array', 'depth_array', 'rgbd_tuple'],
         'render_fps': 10,
     }
 

--- a/ogbench/online_locomotion/ant.py
+++ b/ogbench/online_locomotion/ant.py
@@ -24,6 +24,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
             'human',
             'rgb_array',
             'depth_array',
+            'rgbd_tuple',
         ],
         'render_fps': 10,
     }

--- a/ogbench/online_locomotion/humanoid.py
+++ b/ogbench/online_locomotion/humanoid.py
@@ -90,7 +90,7 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
 
     xml_file = os.path.join(os.path.dirname(__file__), 'assets', 'humanoid.xml')
     metadata = {
-        'render_modes': ['human', 'rgb_array', 'depth_array'],
+        'render_modes': ['human', 'rgb_array', 'depth_array', 'rgbd_tuple'],
         'render_fps': 40,
     }
 


### PR DESCRIPTION
Thanks for the great work and clean code for ogbench.

With a new install `pip install ogbench`, the [new release of gymnasium==1.1.0 ](https://github.com/Farama-Foundation/Gymnasium/releases/tag/v1.1.0)is installed, and it breaks make_env_and_datasets()

The new release assert `render_modes` in the following [way](https://github.com/Farama-Foundation/Gymnasium/blob/9ff8bf45dd765fae4cadec57873c69345e61e28e/gymnasium/envs/mujoco/mujoco_env.py#L85) by adding 'rgbd_tuple' which is not added in the metadata for [PointEnv](https://github.com/hany606/ogbench/blob/0a30a104e0deb87bf7896bf005064303e9d691a2/ogbench/locomaze/point.py#L18), [AntEnv](https://github.com/hany606/ogbench/blob/0a30a104e0deb87bf7896bf005064303e9d691a2/ogbench/locomaze/ant.py#L18), [HumanoidEnv](https://github.com/hany606/ogbench/blob/0a30a104e0deb87bf7896bf005064303e9d691a2/ogbench/locomaze/humanoid.py#L19)

```
assert self.metadata["render_modes"] == [
    "human",
    "rgb_array",
    "depth_array",
    "rgbd_tuple",
], self.metadata["render_modes"]
```

Another option to keep `gymnasium[mujoco]==1.0.0` in [pyproject.toml](https://github.com/hany606/ogbench/blob/cf9ff2e4e703bdaeba4217513cb68afcb56ecb73/pyproject.toml#L12)

Please, let me know if there is a better way to solve it
