### PR TITLE
Maintain backwards compatibility with gymnasium<1.1.0

### DIFF
--- a/ogbench/locomaze/ant.py
+++ b/ogbench/locomaze/ant.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import gymnasium
 from gymnasium import utils
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
@@ -16,9 +17,11 @@ class AntEnv(MujocoEnv, utils.EzPickle):
 
     xml_file = os.path.join(os.path.dirname(__file__), 'assets', 'ant.xml')
     metadata = {
-        'render_modes': ['human', 'rgb_array', 'depth_array', 'rgbd_tuple'],
+        'render_modes': ['human', 'rgb_array', 'depth_array'],
         'render_fps': 10,
     }
+    if gymnasium.__version__ >= '1.1.0':
+        metadata['render_modes'] += ['rgbd_tuple']
 
     def __init__(
         self,

--- a/ogbench/locomaze/humanoid.py
+++ b/ogbench/locomaze/humanoid.py
@@ -3,6 +3,7 @@ import os
 
 import mujoco
 import numpy as np
+import gymnasium
 from gymnasium import utils
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
@@ -17,9 +18,11 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
 
     xml_file = os.path.join(os.path.dirname(__file__), 'assets', 'humanoid.xml')
     metadata = {
-        'render_modes': ['human', 'rgb_array', 'depth_array', 'rgbd_tuple'],
+        'render_modes': ['human', 'rgb_array', 'depth_array'],
         'render_fps': 40,
     }
+    if gymnasium.__version__ >= '1.1.0':
+        metadata['render_modes'] += ['rgbd_tuple']
 
     def __init__(
         self,

--- a/ogbench/locomaze/point.py
+++ b/ogbench/locomaze/point.py
@@ -2,6 +2,7 @@ import os
 
 import mujoco
 import numpy as np
+import gymnasium
 from gymnasium import utils
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
@@ -16,9 +17,11 @@ class PointEnv(MujocoEnv, utils.EzPickle):
 
     xml_file = os.path.join(os.path.dirname(__file__), 'assets', 'point.xml')
     metadata = {
-        'render_modes': ['human', 'rgb_array', 'depth_array', 'rgbd_tuple'],
+        'render_modes': ['human', 'rgb_array', 'depth_array'],
         'render_fps': 10,
     }
+    if gymnasium.__version__ >= '1.1.0':
+        metadata['render_modes'] += ['rgbd_tuple']
 
     def __init__(
         self,

--- a/ogbench/online_locomotion/ant.py
+++ b/ogbench/online_locomotion/ant.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import gymnasium
 from gymnasium import utils
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
@@ -20,9 +21,11 @@ class AntEnv(MujocoEnv, utils.EzPickle):
 
     xml_file = os.path.join(os.path.dirname(__file__), 'assets', 'ant.xml')
     metadata = {
-        'render_modes': ['human', 'rgb_array', 'depth_array', 'rgbd_tuple'],
+        'render_modes': ['human', 'rgb_array', 'depth_array'],
         'render_fps': 10,
     }
+    if gymnasium.__version__ >= '1.1.0':
+        metadata['render_modes'] += ['rgbd_tuple']
 
     def __init__(
         self,

--- a/ogbench/online_locomotion/humanoid.py
+++ b/ogbench/online_locomotion/humanoid.py
@@ -4,6 +4,7 @@ import warnings
 
 import mujoco
 import numpy as np
+import gymnasium
 from gymnasium import utils
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
@@ -90,9 +91,11 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
 
     xml_file = os.path.join(os.path.dirname(__file__), 'assets', 'humanoid.xml')
     metadata = {
-        'render_modes': ['human', 'rgb_array', 'depth_array', 'rgbd_tuple'],
+        'render_modes': ['human', 'rgb_array', 'depth_array'],
         'render_fps': 40,
     }
+    if gymnasium.__version__ >= '1.1.0':
+        metadata['render_modes'] += ['rgbd_tuple']
 
     def __init__(
         self,


### PR DESCRIPTION
This PR conditionally adds `rgbd_tuple` depending on the version of gymnasium. Right now if you're using ogbench with `gymnasium<1.1.0` the internal assertion will be raised due to having `rgbd_tuple` in the array.