### PR TITLE
Fix TypeError in reshape_video due to NumPy 2.0 newshape removal

### DIFF
--- a/impls/utils/log_utils.py
+++ b/impls/utils/log_utils.py
@@ -106,9 +106,9 @@ def reshape_video(v, n_cols=None):
         v = np.concatenate((v, np.zeros(shape=(len_addition, t, h, w, c))), axis=0)
     n_rows = v.shape[0] // n_cols
 
-    v = np.reshape(v, newshape=(n_rows, n_cols, t, h, w, c))
+    v = np.reshape(v, (n_rows, n_cols, t, h, w, c))
     v = np.transpose(v, axes=(2, 5, 0, 3, 1, 4))
-    v = np.reshape(v, newshape=(t, c, n_rows * h, n_cols * w))
+    v = np.reshape(v, (t, c, n_rows * h, n_cols * w))
 
     return v
 


### PR DESCRIPTION
Fixes #38 

### Description
Reference: #38 

Removes the `newshape` keyword argument from `np.reshape` calls in `impls/utils/log_utils.py`, replacing it with a positional argument. This resolves compatibility issues with NumPy 2.x where `newshape` is no longer a valid keyword argument, while maintaining backward compatibility with NumPy 1.x.

### Reproduction (Verification of Fix)
The break can be demonstrated deterministically.

**Before (Fails on NumPy 2.x):**
```python
import numpy as np
# TypeError: reshape() got an unexpected keyword argument 'newshape'
np.reshape(np.zeros(4), newshape=(2, 2))
```

**After (Works on NumPy 1.x and 2.x):**
```python
import numpy as np
# Success
np.reshape(np.zeros(4), (2, 2))
```

### Changes
- `impls/utils/log_utils.py`: Switch `np.reshape(..., newshape=...)` to `np.reshape(..., ...)`